### PR TITLE
[Feature] event2 result 전환 애니메이션, 기대평 자동 스크롤

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,19 +6,22 @@ import "./styles/tailwind.css";
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Failed to find the root element");
 
-async function enableMocking() {
-  if (process.env.NODE_ENV !== "development") {
-    return;
-  }
+// async function enableMocking() {
+//   if (process.env.NODE_ENV === "development") {
+//     return;
+//   }
 
-  const { worker } = await import("./mocks/browser");
+//   const { worker } = await import("./mocks/browser");
 
-  // `worker.start()` returns a Promise that resolves
-  // once the Service Worker is up and ready to intercept requests.
-  return worker.start();
-}
+//   // `worker.start()` returns a Promise that resolves
+//   // once the Service Worker is up and ready to intercept requests.
+//   return worker.start();
+// }
 
-enableMocking().then(() => {
-  const root = ReactDOM.createRoot(rootElement);
-  root.render(<App />);
-});
+// enableMocking().then(() => {
+//   const root = ReactDOM.createRoot(rootElement);
+//   root.render(<App />);
+// });
+
+const root = ReactDOM.createRoot(rootElement);
+root.render(<App />);

--- a/src/pages/randomEventResultPage/RandomEventResultPage.tsx
+++ b/src/pages/randomEventResultPage/RandomEventResultPage.tsx
@@ -16,32 +16,32 @@ const RandomEventResultPage = () => {
   ];
   const scenarioList = [
     {
-      img: "path",
+      image: "path",
       title: "차로 이탈 시 경고 / 자동 조항 보조",
-      content:
+      subtitle:
         "정신 없이 바쁜 일상 속에서도 셀토스는 일정 속도 이상 주행 중 방향지시등 스위치 조작 없이 차로 이탈 시 경고 및 자동 조향 보조 기능으로 사용자의 안전을 지켜줍니다.",
     },
     {
-      img: "path",
+      image: "path",
       title: "원격 제어 주차 및 출차",
-      content:
+      subtitle:
         "원격 제어를 통한 주차 및 출차 기능으로 사용자가 좁은 골목길에서도 걱정없이 주차 할 수 있게 돕습니다. ",
     },
     {
-      img: "path",
+      image: "path",
       title: "네비게이션 기반 크루즈 컨트롤",
-      content:
+      subtitle:
         "네비게이션 기반 크루즈 컨트롤을 통해 고속도로 주행 시, 도로 상황에 맞춰 안전한 속도로 주행하도록 도와줍니다.",
     },
   ];
 
   const ROULETTE_END_CONTAINER_CLASSES = {
-    true: "justify-start",
+    true: "justify-end",
     false: "justify-center",
   };
 
   const ROULETTE_END_HEADER_CLASSES = {
-    true: "mt-[4.5rem] gap-4",
+    true: "gap-4",
     false: "gap-6",
   };
 
@@ -68,11 +68,9 @@ const RandomEventResultPage = () => {
   }, []);
 
   return (
-    <div
-      className={`flex h-screen w-screen flex-col items-center ${ROULETTE_END_CONTAINER_CLASSES[`${isRouletteEnd}`]} gap-16 overflow-scroll bg-black transition-all duration-300`}
-    >
+    <div className="relative flex flex-col items-center">
       <div
-        className={`relative flex w-[36.5rem] flex-col items-center ${headerStyle}`}
+        className={`absolute flex w-[36.5rem] flex-col items-center transition-all duration-500 ${headerStyle}`}
       >
         <p className="text-center font-kia-signature-bold text-title-3 text-gray-50">
           당신의 운전자 유형은?
@@ -82,20 +80,24 @@ const RandomEventResultPage = () => {
           targetText={driverType}
         ></Roulette>
       </div>
-      {!isRouletteEnd && (
-        <img
-          src={car}
-          alt="자동차"
-          className={`${animation ? "animate-fadeOut" : ""}`}
-        />
-      )}
-      {isRouletteEnd && (
-        <RandomMainSection
-          description={description}
-          scenarioList={scenarioList}
-        />
-      )}
-      {isRouletteEnd && isAuth && <RandomExpectations />}
+      <div
+        className={`flex h-screen w-screen flex-col items-center ${ROULETTE_END_CONTAINER_CLASSES[`${isRouletteEnd}`]} gap-16 overflow-scroll bg-black transition-all duration-300`}
+      >
+        {!isRouletteEnd && (
+          <img
+            src={car}
+            alt="자동차"
+            className={`${animation ? "animate-fadeOut" : ""}`}
+          />
+        )}
+        {isRouletteEnd && (
+          <RandomMainSection
+            description={description}
+            scenarioList={scenarioList}
+          />
+        )}
+        {isRouletteEnd && isAuth && <RandomExpectations />}
+      </div>
     </div>
   );
 };

--- a/src/pages/randomEventResultPage/RandomEventResultPage.tsx
+++ b/src/pages/randomEventResultPage/RandomEventResultPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useAppContext } from "../../providers/AppProvider";
 import RandomMainSection from "./RandomMainSection/RandomMainSection";
 import RandomExpectations from "./RandomExpectations/RandomExpectations";
@@ -36,21 +36,28 @@ const RandomEventResultPage = () => {
   ];
 
   const ROULETTE_END_CONTAINER_CLASSES = {
-    true: "justify-end",
+    true: "justify-start pt-[16rem]",
     false: "justify-center",
   };
 
   const ROULETTE_END_HEADER_CLASSES = {
-    true: "gap-4",
-    false: "gap-6",
+    true: "gap-4 top-12",
+    false: "gap-6 top-[16rem]",
   };
 
   const [isRouletteEnd, setIsRouletteEnd] = useState(false);
   const [animation, setAnimation] = useState(false);
   const appContext = useAppContext();
   const { isAuth } = appContext;
+  const randomExpectationsRef = useRef<HTMLDivElement>(null);
 
   const headerStyle = ROULETTE_END_HEADER_CLASSES[`${isRouletteEnd}`];
+  const EX_ANSWER = {
+    answer1: "A",
+    answer2: "A",
+    answer3: "A",
+    answer4: "A",
+  };
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
@@ -61,42 +68,69 @@ const RandomEventResultPage = () => {
       setAnimation(true);
     }, 5000);
 
+    const fetchData = async () => {
+      const response = await postAnswers(EX_ANSWER);
+
+      console.log(response);
+    };
+
+    fetchData();
+
     return () => {
       clearTimeout(timeoutId);
       clearTimeout(animationTimeout);
     };
   }, []);
 
+  const postAnswers = async (answers: any): Promise<any> => {
+    fetch("http://13.124.183.61:8081/v1/quiz")
+      .then((response) => response.json()) // JSON 응답을 받기
+      .then((data) => console.log(data)) // 성공적으로 응답을 받은 경우 처리
+      .catch((error) => console.error("Error:", error)); // 오류가 발생한 경우 처리
+  };
+
+  useEffect(() => {
+    if (isAuth && randomExpectationsRef.current) {
+      // RandomExpectations 요소로 스크롤
+      randomExpectationsRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  }, [isAuth]);
+
   return (
-    <div className="relative flex flex-col items-center">
+    <div className="flex flex-col items-center transition-all duration-500">
       <div
-        className={`absolute flex w-[36.5rem] flex-col items-center transition-all duration-500 ${headerStyle}`}
+        className={`relative flex h-screen w-screen flex-col items-center ${ROULETTE_END_CONTAINER_CLASSES[`${isRouletteEnd}`]} gap-16 overflow-scroll bg-black transition-all duration-300`}
       >
-        <p className="text-center font-kia-signature-bold text-title-3 text-gray-50">
-          당신의 운전자 유형은?
-        </p>
-        <Roulette
-          textList={DRIVER_TYPE_LIST}
-          targetText={driverType}
-        ></Roulette>
-      </div>
-      <div
-        className={`flex h-screen w-screen flex-col items-center ${ROULETTE_END_CONTAINER_CLASSES[`${isRouletteEnd}`]} gap-16 overflow-scroll bg-black transition-all duration-300`}
-      >
-        {!isRouletteEnd && (
-          <img
-            src={car}
-            alt="자동차"
-            className={`${animation ? "animate-fadeOut" : ""}`}
-          />
-        )}
+        <div
+          className={`absolute flex w-[36.5rem] flex-col items-center duration-500 ${headerStyle}`}
+        >
+          <p className="text-center font-kia-signature-bold text-title-3 text-gray-50">
+            당신의 운전자 유형은?
+          </p>
+          <Roulette
+            textList={DRIVER_TYPE_LIST}
+            targetText={driverType}
+          ></Roulette>
+          {!isRouletteEnd && (
+            <img
+              src={car}
+              alt="자동차"
+              className={`${animation ? "animate-fadeOut" : ""}`}
+            />
+          )}
+        </div>
         {isRouletteEnd && (
-          <RandomMainSection
-            description={description}
-            scenarioList={scenarioList}
-          />
+          <div className="animate-moveSection">
+            <RandomMainSection
+              description={description}
+              scenarioList={scenarioList}
+            />
+            {isAuth && <RandomExpectations ref={randomExpectationsRef} />}
+          </div>
         )}
-        {isRouletteEnd && isAuth && <RandomExpectations />}
       </div>
     </div>
   );

--- a/src/pages/randomEventResultPage/RandomExpectations/RandomExpectations.tsx
+++ b/src/pages/randomEventResultPage/RandomExpectations/RandomExpectations.tsx
@@ -1,8 +1,8 @@
-import React, { ChangeEvent, useState } from "react";
+import React, { ChangeEvent, forwardRef, useState } from "react";
 import Toast from "../../../components/common/Toast/Toast";
 import { ERROR_MSG } from "../../../constants/RandomEventData";
 
-const RandomExpectations = () => {
+const RandomExpectations = forwardRef<HTMLDivElement>((props, ref) => {
   const [error, setError] = useState<"short" | "inappropriate" | null>(null);
   const [expectation, setExpectation] = useState<string>("");
   const [toastKey, setToastKey] = useState(0);
@@ -27,12 +27,12 @@ const RandomExpectations = () => {
   };
 
   return (
-    <div className="relative w-[94rem]">
+    <div className="mb-[4.5rem] w-[94rem]" ref={ref}>
       <hr className="h-[1px] bg-gray-400" />
       <p className="mb-8 mt-[4.5rem] font-kia-signature-bold text-title-2 text-gray-50">
         기대평 작성 시, 당첨 확률 up!
       </p>
-      <div className="h-[16.875rem] gap-5 rounded-[2.5rem] bg-gray-950 flex-center">
+      <div className="relative h-[16.875rem] gap-5 rounded-[2.5rem] bg-gray-950 flex-center">
         <textarea
           onChange={handleTextArea}
           value={expectation}
@@ -45,19 +45,19 @@ const RandomExpectations = () => {
         >
           참여하기
         </button>
+        {error && (
+          <Toast
+            key={toastKey}
+            content={ERROR_MSG[`${error}`]}
+            position="bottom"
+            value={4}
+            delay={4000}
+            duration={1000}
+          />
+        )}
       </div>
-      {error && (
-        <Toast
-          key={toastKey}
-          content={ERROR_MSG[`${error}`]}
-          position="bottom"
-          value={4}
-          delay={4000}
-          duration={1000}
-        />
-      )}
     </div>
   );
-};
+});
 
 export default RandomExpectations;

--- a/src/pages/randomEventResultPage/RandomMainSection/RandomMainSection.tsx
+++ b/src/pages/randomEventResultPage/RandomMainSection/RandomMainSection.tsx
@@ -13,9 +13,9 @@ interface DescriptionInterface {
 }
 
 interface ScenarioInterface {
-  img: string;
+  image: string;
   title: string;
-  content: string;
+  subtitle: string;
 }
 
 const RandomMainSection = ({
@@ -66,7 +66,7 @@ const RandomMainSection = ({
             <div key={index} className="flex flex-col gap-3">
               <p className="font-kia-signature-bold text-body-1-bold text-gray-50">{`${index + 1}.`}</p>
               <img
-                src={scenario.img}
+                src={scenario.image}
                 alt="시나리오"
                 className="h-[15.25rem] w-[28.75rem] rounded-xl"
               />
@@ -74,7 +74,7 @@ const RandomMainSection = ({
                 {scenario.title}
               </p>
               <p className="w-[26rem] font-kia-signature text-body-1-regular text-gray-300">
-                {scenario.content}
+                {scenario.subtitle}
               </p>
             </div>
           ))}

--- a/src/pages/randomEventResultPage/RandomMainSection/RandomMainSection.tsx
+++ b/src/pages/randomEventResultPage/RandomMainSection/RandomMainSection.tsx
@@ -33,20 +33,22 @@ const RandomMainSection = ({
     //공유 링크 복사
   };
 
+  const { setIsAuth } = useAppContext();
   const onClickHandler = () => {
     if (isAuth) {
       //이벤트 참여 백에 전달
     } else {
       //본인인증 모달
       //본인인증 대기
+      setIsAuth(true);
     }
     //기대평 작성창
   };
 
   return (
-    <div className="animate-moveSection w-[94rem]">
+    <div className="mb-24 w-[94rem]">
       <div className="relative flex h-[36.25rem] w-[94rem] flex-col gap-6 rounded-[2.5rem] border-white border-opacity-15 bg-white bg-opacity-10 p-10 backdrop-blur-lg">
-        <div className="absolute right-0 flex gap-8">
+        <div className="absolute right-0 top-3 flex gap-4 font-kia-signature-bold text-body-1-bold text-white">
           <button onClick={handleRetry}>다시하기</button>
           <button onClick={handleShare}>공유하기</button>
         </div>


### PR DESCRIPTION
## 🎯 이슈 번호
#35 

## 💡 작업 내용

- [x] 기대평 자동 스크롤
- [x] api 호출 테스트
- [x] 룰렛 종료 전환 애니메이션

## 💡 자세한 설명


https://github.com/user-attachments/assets/51d35188-48a6-45d4-a2d2-46cc4f7ebe01



CORS 이슈로 인해 정확한 테스트 실패
absolute 요소 스크롤에 포함하기 위해 한번 더 div로 감싸는 구조로 변경
자동 스크롤을 위해서 forwardRef 사용

++ 바로 dev에 푸쉬했던 작업
event2 quiz section의 덜컹거림 opacity로 해결
화면비 문제 해결
- 디자인 그대로 fix하면 비율 망가짐
- 요소가 중앙에 있는 디자인은 최대한 center로 해결

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
다시하기, 공유하기 스타일과 로직만 완료하면 이벤트 2 결과 페이지는 완료
