### PR TITLE
[Feature] 인증모달 테스트, 스타일, 로직 구현 및 선착순 힌트 페이지 수정

### DIFF
--- a/src/api/fetch.ts
+++ b/src/api/fetch.ts
@@ -1,13 +1,62 @@
+import { PhoneAuthCheckForm, PhoneAuthRequestForm } from "../types/AuthModal";
 import { FCFSResult, QuizInfo } from "../types/FCFSEvent";
 
+/**
+ * 선착순 퀴즈 정보를 가져오는 api
+ * @returns
+ */
 export const fetchFCFSQuizInfo = async (): Promise<QuizInfo> => {
-  const response = await fetch("http://localhost:5000/v1/quiz");
+  const response = await fetch("/v1/quiz");
+
   return await response.json();
 };
 
+/**
+ * 선착순 퀴즈 결과를 가져오는 api
+ * @returns
+ */
 export const fetchFCFSResult = async (): Promise<FCFSResult> => {
-  const response = await fetch("http://localhost:5000/v1/quiz", {
+  const response = await fetch("/v1/quiz", {
     method: "POST",
   });
+
+  return await response.json();
+};
+
+/**
+ * 휴대폰 인증 요청을 보내는 api
+ * @param {PhoneAuthRequestForm} phoneAuthRequestForm - 이름, 전화번호 정보가 들어간 객체
+ * @returns
+ */
+export const postPhoneAuthRequest = async (
+  phoneAuthRequestForm: PhoneAuthRequestForm,
+): Promise<Object> => {
+  const response = await fetch("/verification/claim", {
+    method: "POST",
+    body: JSON.stringify(phoneAuthRequestForm),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  return await response.json();
+};
+
+/**
+ * 회원 인증하는 api
+ * @param {PhoneAuthCheckForm} phoneAuthCheckForm - 이름, 전화번호, 인증번호 정보가 들어간 객체
+ * @returns
+ */
+export const postPhoneAuthCheckRequestTemp = async (
+  phoneAuthCheckForm: PhoneAuthCheckForm,
+): Promise<Object> => {
+  const response = await fetch("/verification/check", {
+    method: "POST",
+    body: JSON.stringify(phoneAuthCheckForm),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
   return await response.json();
 };

--- a/src/api/fetch.ts
+++ b/src/api/fetch.ts
@@ -1,4 +1,8 @@
-import { PhoneAuthCheckForm, PhoneAuthRequestForm } from "../types/AuthModal";
+import {
+  PhoneAuthCheckForm,
+  PhoneAuthRequestForm,
+  PhoneAuthVerifyResult,
+} from "../types/AuthModal";
 import { FCFSResult, QuizInfo } from "../types/FCFSEvent";
 
 /**
@@ -47,9 +51,9 @@ export const postPhoneAuthRequest = async (
  * @param {PhoneAuthCheckForm} phoneAuthCheckForm - 이름, 전화번호, 인증번호 정보가 들어간 객체
  * @returns
  */
-export const postPhoneAuthCheckRequestTemp = async (
+export const postPhoneAuthCheckRequest = async (
   phoneAuthCheckForm: PhoneAuthCheckForm,
-): Promise<Object> => {
+): Promise<PhoneAuthVerifyResult> => {
   const response = await fetch("/verification/check", {
     method: "POST",
     body: JSON.stringify(phoneAuthCheckForm),

--- a/src/components/common/AuthTooltip/AuthTooltip.tsx
+++ b/src/components/common/AuthTooltip/AuthTooltip.tsx
@@ -1,35 +1,15 @@
 import React, { useEffect, useState } from "react";
 import RefreshButton from "../../../assets/svg/RefreshButton";
+import useTimer from "../../../hooks/useTimer";
 
 interface AuthTooltipProps {
   isAuth: boolean;
 }
 
 const AuthTooltip = ({ isAuth }: AuthTooltipProps) => {
-  const MINUTES_IN_MS = 60 * 60 * 1000 - 1000;
-  const INTERVAL = 1000;
-  const [leftTime, setLeftTime] = useState<number>(MINUTES_IN_MS);
+  const initialTime = 60 * 60 * 1000 - 1000;
 
-  const minutes = String(Math.floor((leftTime / (1000 * 60)) % 60)).padStart(
-    2,
-    "0",
-  );
-  const second = String(Math.floor((leftTime / 1000) % 60)).padStart(2, "0");
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setLeftTime((prevTime) => prevTime - INTERVAL);
-    }, INTERVAL);
-
-    if (leftTime <= 0) {
-      clearInterval(timer);
-      // 종료 로직
-    }
-
-    return () => {
-      clearInterval(timer);
-    };
-  }, [leftTime]);
+  const { reset, minutes, second } = useTimer(initialTime);
 
   return (
     <>
@@ -45,9 +25,7 @@ const AuthTooltip = ({ isAuth }: AuthTooltipProps) => {
             <span className="text-center font-kia-signature-bold text-body-2-bold">
               {minutes} : {second}
             </span>
-            <RefreshButton
-              onClick={() => setLeftTime(MINUTES_IN_MS)}
-            ></RefreshButton>
+            <RefreshButton onClick={reset}></RefreshButton>
           </div>
         </div>
       ) : (

--- a/src/constants/AuthModal.ts
+++ b/src/constants/AuthModal.ts
@@ -1,5 +1,4 @@
 export const MESSAGE = {
-  INVALID_FORMAT: "잘못된 번호 형식입니다.",
   AUTH_NUM_EXPRIES: "인증시간이 만료되었습니다.",
   AUTH_NUM_INCORRECT: "인증번호가 틀렸습니다. 다시 입력해주세요.",
 };

--- a/src/constants/AuthModal.ts
+++ b/src/constants/AuthModal.ts
@@ -1,0 +1,7 @@
+export const MESSAGE = {
+  INVALID_FORMAT: "잘못된 번호 형식입니다.",
+  AUTH_NUM_EXPRIES: "인증시간이 만료되었습니다.",
+  AUTH_NUM_INCORRECT: "인증번호가 틀렸습니다. 다시 입력해주세요.",
+};
+
+export const AUTH_DELAY = 3 * 60 * 1000;

--- a/src/constants/AuthModal.ts
+++ b/src/constants/AuthModal.ts
@@ -5,3 +5,12 @@ export const MESSAGE = {
 };
 
 export const AUTH_DELAY = 3 * 60 * 1000;
+
+export const PERSONAL_INFO_NOTICE = [
+  { key: "개인정보 수집 목적", value: "The 2025 셀토스 출시 Event" },
+  { key: "개인정보 수집 항목", value: "성명, 휴대전화번호" },
+  {
+    key: "개인정보 보유 및 이용 기간",
+    value: "이벤트 당첨자 발표 및 경품제공 후 즉시 파기",
+  },
+];

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -15,9 +15,6 @@ interface UseAnimationProps {
  * @param {KeyframeAnimationOptions} props.options - 시작 시 적용할 keyframe 배열
  * @returns
  * @example
- * import React from 'react';
- * import { useAnimation } from './src/hooks/useAnimation';
- *
  * const AnimatedComponent = () => {
  *   const { elementRef, startAnimation } = useAnimation({
  *     startKeyframes: [

--- a/src/hooks/useInputs.tsx
+++ b/src/hooks/useInputs.tsx
@@ -1,0 +1,36 @@
+import React, { ChangeEvent, useState } from "react";
+
+/**
+ * 입력 Custom Hook
+ * @template T - Form의 type
+ * @param initialForm - 초기 설정 데이터
+ * @returns
+ * @example
+ * const InputComponent = () => {
+ *   const { form, onChange, reset } = useInputs({
+ *     name: "",
+ *     phontNumber: "",
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       <input name="name" placeholder="이름" onChange={onChange} value={name} />
+ *     </div>
+ *   );
+ * }; */
+const useInputs = <T extends Object>(initialForm: T) => {
+  const [form, setForm] = useState(initialForm);
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prevForm) => ({ ...prevForm, [name]: value }));
+  };
+
+  const reset = () => {
+    setForm(initialForm);
+  };
+
+  return { form, onChange, reset };
+};
+
+export default useInputs;

--- a/src/hooks/useInputs.tsx
+++ b/src/hooks/useInputs.tsx
@@ -17,7 +17,8 @@ import React, { ChangeEvent, useState } from "react";
  *       <input name="name" placeholder="이름" onChange={onChange} value={name} />
  *     </div>
  *   );
- * }; */
+ * };
+ * */
 const useInputs = <T extends Object>(initialForm: T) => {
   const [form, setForm] = useState(initialForm);
 

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+
+/**
+ * 타이머 Custom Hook
+ * @param {number} initialTime - 초기 설정 시간
+ * @param {Function} onEndHandler - 종료 시 실행될 로직
+ * @returns
+ * @example
+ * const TimerComponent = () => {
+ *   const { reset, minutes, second } = useTimer(1000, () => navigate("/"));
+ *
+ *   return (
+ *     <div>
+ *       {minutes} : {second}
+ *     </div>
+ *   );
+ * };
+ * */
+const useTimer = (initialTime: number, onEndHandler?: Function) => {
+  const [leftTime, setLeftTime] = useState(initialTime);
+
+  const INTERVAL = 1000;
+  const minutes = String(Math.floor((leftTime / (1000 * 60)) % 60)).padStart(
+    2,
+    "0",
+  );
+  const second = String(Math.floor((leftTime / 1000) % 60)).padStart(2, "0");
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setLeftTime((prevTime) => prevTime - INTERVAL);
+    }, INTERVAL);
+
+    if (leftTime <= 0) {
+      clearInterval(timer);
+      if (onEndHandler) onEndHandler();
+    }
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [leftTime]);
+
+  const reset = () => {
+    setLeftTime(initialTime);
+  };
+
+  return { reset, minutes, second };
+};
+
+export default useTimer;

--- a/src/mocks/data/AuthModal.ts
+++ b/src/mocks/data/AuthModal.ts
@@ -1,0 +1,12 @@
+import { PhoneAuthVerifyResult } from "../../types/AuthModal";
+
+export const phoneAuthCheckResult: PhoneAuthVerifyResult = {
+  isSuccess: true,
+  code: 200,
+  message: "요청에 성공했습니다.",
+  result: {
+    accessToken:
+      "Bearer mockeyJlbmMiOiJBMjU2R0NNIiwiYWxnlyIn0..9OhMZWH54Txf0unu.91CJloJCRtZ1zV1Fo5CHFSNLaV8U8z8vlQazTUop9FXHOhHb8GWBIx_8C97YHFOXJBp-uN2bE9q895U-LOb9jEhsMChgEi36WNjUsM-4KFiEbHSSvCb5Ln1bvwkRoJSSMuWOR9nZjNthBGj0w5VYBPjRLN_QXL9bXMMuFUOio0w2JHq8pqYnVxBIkhWD-c.AzVa-m6RLQ",
+    expireTime: 3600000,
+  },
+};

--- a/src/mocks/handler/AuthModal.ts
+++ b/src/mocks/handler/AuthModal.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from "msw";
+import { phoneAuthCheckResult } from "../data/AuthModal";
+
+const postPhoneAuthRequest = http.post("/verification/claim", () => {
+  return HttpResponse.json({ success: true });
+});
+
+const postPhoneAuthCheck = http.post("/verification/check", () => {
+  return HttpResponse.json(phoneAuthCheckResult);
+});
+
+export default [postPhoneAuthRequest, postPhoneAuthCheck];

--- a/src/mocks/handler/FCFSEvent.ts
+++ b/src/mocks/handler/FCFSEvent.ts
@@ -1,11 +1,11 @@
 import { http, HttpResponse } from "msw";
 import { FCFSFailResult, FCFSSuccessResult, quizInfo } from "../data/FCFSEvent";
 
-const getQuizInfo = http.get("http://localhost:5000/v1/quiz", () => {
+const getQuizInfo = http.get("/v1/quiz", () => {
   return HttpResponse.json(quizInfo);
 });
 
-const getFCFSResult = http.post("http://localhost:5000/v1/quiz", () => {
+const getFCFSResult = http.post("/v1/quiz", () => {
   return HttpResponse.json(FCFSSuccessResult);
 });
 

--- a/src/mocks/handler/index.ts
+++ b/src/mocks/handler/index.ts
@@ -1,5 +1,6 @@
+import AuthModal from "./AuthModal";
 import FCFSEvent from "./FCFSEvent";
 
-const handlers = [...FCFSEvent];
+const handlers = [...FCFSEvent, ...AuthModal];
 
 export default handlers;

--- a/src/pages/FCFSEventPage/FCFSHintSection.tsx
+++ b/src/pages/FCFSEventPage/FCFSHintSection.tsx
@@ -143,48 +143,52 @@ const FCFSHintSection = (
         <p>▼</p>
       </div>
       <div
-        role="dialog"
+        className="absolute -bottom-[43rem] h-[44.5rem] w-[86rem]"
         ref={ref}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        className="absolute -bottom-[43rem] grid h-[44.5rem] w-[86rem] grid-cols-4 grid-rows-4 gap-4 rounded-[2.75rem] bg-white/10 p-700 backdrop-blur-sm"
       >
-        {hintInfo.map(({ id, content, img, grid }, index) => {
-          return (
-            <div role="listitem" key={id} className={`${grid}`}>
-              <div
-                style={{ backgroundImage: `url(${img})` }}
-                className="h-full w-full rounded-[1.25rem] bg-cover bg-center font-kia-signature-bold text-title-4 text-white flex-center"
-              >
-                {content}
+        <div
+          role="dialog"
+          className="grid h-full grid-cols-4 grid-rows-4 gap-4 rounded-[2.75rem] bg-white/10 p-700 backdrop-blur-sm"
+        >
+          {hintInfo.map(({ id, content, img, grid }, index) => {
+            return (
+              <div role="listitem" key={id} className={`${grid}`}>
+                <div
+                  style={{ backgroundImage: `url(${img})` }}
+                  className="h-full w-full rounded-[1.25rem] bg-cover bg-center font-kia-signature-bold text-title-4 text-white flex-center"
+                >
+                  {content}
+                </div>
               </div>
-            </div>
-          );
-        })}
-        <div className="col-start-4 col-end-5 row-start-1 row-end-5 rounded-[1.25rem] bg-gradient-to-b from-black to-gray-300">
-          <div
-            style={{ backgroundImage: `url(${hint7})` }}
-            className="h-full w-full bg-contain bg-bottom bg-no-repeat"
-            role="listitem"
-          >
-            {gasolineInfo.map(({ id, title, value }, index) => {
-              if (index === 0)
-                return (
-                  <div key={id}>
-                    <GasolineInfo id={id} title={title} value={value} />
-                    <div className="flex-center">
-                      <hr className="w-4/5 bg-gray-500" />
+            );
+          })}
+          <div className="col-start-4 col-end-5 row-start-1 row-end-5 rounded-[1.25rem] bg-gradient-to-b from-black to-gray-300">
+            <div
+              style={{ backgroundImage: `url(${hint7})` }}
+              className="h-full w-full bg-contain bg-bottom bg-no-repeat"
+              role="listitem"
+            >
+              {gasolineInfo.map(({ id, title, value }, index) => {
+                if (index === 0)
+                  return (
+                    <div key={id}>
+                      <GasolineInfo id={id} title={title} value={value} />
+                      <div className="flex-center">
+                        <hr className="w-4/5 bg-gray-500" />
+                      </div>
                     </div>
-                  </div>
-                );
-              else
-                return (
-                  <GasolineInfo key={8} id={id} title={title} value={value} />
-                );
-            })}
+                  );
+                else
+                  return (
+                    <GasolineInfo key={8} id={id} title={title} value={value} />
+                  );
+              })}
+            </div>
           </div>
         </div>
-        <div className="h-6 w-screen bg-white">ddddd</div>
+        <div className="h-[30rem] w-full bg-transparent"></div>
       </div>
     </>
   );

--- a/src/pages/authModal/AuthModal.stories.tsx
+++ b/src/pages/authModal/AuthModal.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Meta } from "@storybook/react/*";
+import AuthModal from "./AuthModal";
+import { BrowserRouter } from "react-router-dom";
+
+const meta: Meta<typeof AuthModal> = {
+  component: AuthModal,
+  title: "AuthModal",
+  tags: ["autodocs"],
+  excludeStories: /.*Data$/,
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+export const Default = {
+  args: {},
+};
+
+export default meta;

--- a/src/pages/authModal/AuthModal.test.tsx
+++ b/src/pages/authModal/AuthModal.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen } from "../../utils/test-utils";
+import AuthModal from "./AuthModal";
+import userEvent from "@testing-library/user-event";
+import { AUTH_DELAY, MESSAGE } from "../../constants/AuthModal";
+
+jest.useFakeTimers();
+
+describe("AuthModal Component 렌더링 및 입력 테스트", () => {
+  test("개인정보를 입력할 수 있는 입력창과 인증 버튼이 화면에 보여야 한다.", () => {
+    render(<AuthModal />);
+
+    const phoneNumberInput = screen.getByPlaceholderText("전화번호");
+    expect(phoneNumberInput).toBeInTheDocument();
+
+    const authButton = screen.getByRole("button", { name: "인증하기" });
+    expect(authButton).toBeInTheDocument();
+  });
+
+  test("뒷 배경이 블러 처리 되야 한다.", () => {});
+
+  test("입력창에 알맞은 형식의 텍스트를 입력할 수 있어야 한다.", async () => {
+    render(<AuthModal />);
+
+    const phoneNumberInput = screen.getByPlaceholderText("전화번호");
+    await userEvent.type(phoneNumberInput, "01022222222");
+
+    expect(phoneNumberInput).toHaveValue("01022222222");
+  });
+
+  test("이름의 올바른 형식(한글)이 아니면 오류를 반환해야 한다.", async () => {
+    render(<AuthModal />);
+
+    const phoneNumberInput = screen.getByPlaceholderText("전화번호");
+    await userEvent.type(phoneNumberInput, "010222avsljla");
+
+    const errorToast = screen.getByRole("alert", {
+      name: MESSAGE.INVALID_FORMAT,
+    });
+
+    expect(errorToast).toBeInTheDocument();
+  });
+
+  test("전화번호 형식이 올바르지 않으면 오류 토스트를 보여줘야 한다.", async () => {
+    render(<AuthModal />);
+
+    const nameInput = screen.getByPlaceholderText("이름");
+    await userEvent.type(nameInput, "00avsljla");
+
+    const errorToast = screen.getByRole("alert", {
+      name: MESSAGE.INVALID_FORMAT,
+    });
+
+    expect(errorToast).toBeInTheDocument();
+  });
+});
+
+describe("AuthModal 인증 관련 테스트", () => {
+  beforeEach(async () => {
+    render(<AuthModal />);
+
+    const phoneNumberInput = screen.getByPlaceholderText("전화번호");
+    await userEvent.type(phoneNumberInput, "01022222222");
+  });
+  test("전화번호를 누르고 인증번호 버튼을 누르면 인증 번호 옆에 타이머가 나타나야 한다.", async () => {
+    const phoneAuthButton = screen.getByRole("button", { name: "인증번호" });
+    await userEvent.click(phoneAuthButton);
+
+    const timer = await screen.findByRole("timer");
+    expect(timer).toBeInTheDocument();
+  });
+
+  test("인증 시간이 만료되면 인증시간 만료 토스트를 보여줘야 한다.", async () => {
+    render(<AuthModal />);
+
+    const phoneAuthButton = screen.getByRole("button", { name: "인증번호" });
+    await userEvent.click(phoneAuthButton);
+
+    jest.advanceTimersByTime(AUTH_DELAY);
+
+    const expToast = await screen.findByRole("alert", {
+      name: MESSAGE.AUTH_NUM_EXPRIES,
+    });
+    expect(expToast).toBeInTheDocument();
+  });
+
+  test("인증번호 버튼을 누르면 재전송 버튼으로 바뀌어야 한다.", async () => {
+    const phoneAuthButton = screen.getByRole("button", { name: "인증번호" });
+    await userEvent.click(phoneAuthButton);
+
+    expect(phoneAuthButton).toHaveTextContent("재전송");
+  });
+
+  test("동의 버튼이 눌리지 않으면 인증하기 버튼을 누를 수 없어야 한다.", () => {
+    const authButton = screen.getByRole("button", { name: "인증하기" });
+
+    expect(authButton).toBeDisabled();
+  });
+
+  test("동의 버튼과 미동이 버튼은 서로 토글되어야 한다.", async () => {
+    const agreeButton = screen.getByRole("radio", { name: "동의" });
+    const disagreeButton = screen.getByRole("radio", { name: "미동의" });
+
+    await userEvent.click(agreeButton);
+    expect(agreeButton).toBeChecked();
+    expect(disagreeButton).not.toBeChecked();
+
+    await userEvent.click(disagreeButton);
+    expect(agreeButton).not.toBeChecked();
+    expect(disagreeButton).toBeChecked();
+  });
+
+  test("인증 번호가 맞지 않은 상태에서 인증하기 버튼을 누르면 오류 토스트를 보여줘야 한다.", async () => {
+    render(<AuthModal />);
+
+    const authNumberInput = screen.getByPlaceholderText("인증번호");
+    await userEvent.type(authNumberInput, "111111");
+
+    const errorToast = screen.getByRole("alert", {
+      name: MESSAGE.AUTH_NUM_INCORRECT,
+    });
+
+    expect(errorToast).toBeInTheDocument();
+  });
+
+  test("인증번호를 입력하고 동의 상태에서 인증하기 버튼을 누르면 이전 페이지로 이동해야 한다.", () => {});
+});

--- a/src/pages/authModal/AuthModal.test.tsx
+++ b/src/pages/authModal/AuthModal.test.tsx
@@ -13,7 +13,7 @@ describe("AuthModal Component 렌더링 및 입력 테스트", () => {
     const phoneNumberInput = screen.getByPlaceholderText("전화번호");
     expect(phoneNumberInput).toBeInTheDocument();
 
-    const authButton = screen.getByRole("button", { name: "인증하기" });
+    const authButton = screen.getByRole("button", { name: "인증하기 car" });
     expect(authButton).toBeInTheDocument();
   });
 

--- a/src/pages/authModal/AuthModal.tsx
+++ b/src/pages/authModal/AuthModal.tsx
@@ -8,7 +8,7 @@ const AuthModal = () => {
       <form>
         <input type="text" placeholder="이름" />
         <div>
-          <input type="number" placeholder="전화번호" />
+          <input type="text" placeholder="전화번호" />
           <button>인증번호</button>
         </div>
         <input type="number" placeholder="인증번호" />

--- a/src/pages/authModal/AuthModal.tsx
+++ b/src/pages/authModal/AuthModal.tsx
@@ -1,36 +1,111 @@
-import React from "react";
+import React, { useState } from "react";
+import { PERSONAL_INFO_NOTICE } from "../../constants/AuthModal";
+import Button from "../../components/common/Button/Button";
+import { useNavigate } from "react-router";
+import useInputs from "../../hooks/useInputs";
+import { PhoneAuthForm } from "../../types/AuthModal";
+
+const initialForm: PhoneAuthForm = {
+  name: "",
+  phoneNum: "",
+  verificationCode: "",
+};
 
 const AuthModal = () => {
+  const [isButtonEnabled, setIsButtonEnabled] = useState(true);
+  const navigate = useNavigate();
+
+  const { form, onChange, reset } = useInputs<PhoneAuthForm>(initialForm);
+  const { name, phoneNum, verificationCode } = form;
+
   return (
-    <div>
-      <div>개인정보 수집, 이용에 대한 동의</div>
-      <div>info</div>
-      <form>
-        <input type="text" placeholder="이름" />
-        <div>
-          <input type="text" placeholder="전화번호" />
-          <button>인증번호</button>
+    <div className="h-screen w-screen bg-black opacity-90 flex-center">
+      <div className="h-[52.75rem] w-[35.25rem] flex-col rounded-[2rem] bg-white/20 p-6 px-8 text-white flex-center">
+        <div className="pb-700 font-kia-signature-bold text-title-2">
+          개인정보 수집, 이용에 대한 동의
         </div>
-        <input type="number" placeholder="인증번호" />
-        <p>개인정보 수집 및 이용에 동의하십니까?</p>
-        <p>
-          귀하께서는 본 동의를 거부하실 권리가 있으며, 미 동의시 본 이벤트에
-          참여하실 수 없습니다.
-        </p>
-        <div>
-          <div>
+        <div className="flex w-full flex-col gap-2 border-y border-gray-500 py-700">
+          {PERSONAL_INFO_NOTICE.map((notice) => {
+            return (
+              <div key={notice.key} className="flex w-full">
+                <span className="w-[12.5rem] text-body-2-regular text-gray-300">
+                  {notice.key}
+                </span>
+                <span className="font-kia-signature-bold text-body-2-bold">
+                  {notice.value}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        <form className="flex w-full flex-col gap-600 border-b border-gray-500 py-700">
+          <div className="font-kia-signature-bold text-title-4 text-gray-50">
+            개인정보 입력
+          </div>
+          <input
+            className="h-[3.375rem] w-full rounded-lg border border-white/15 bg-white/10 p-500 font-kia-signature text-body-1-regular text-gray-50 placeholder:font-kia-signature placeholder:text-body-1-regular placeholder:text-gray-400"
+            type="text"
+            name="name"
+            value={name}
+            onChange={onChange}
+            placeholder="이름"
+          />
+          <div className="flex gap-2">
+            <input
+              className="h-[3.375rem] w-[24rem] rounded-lg border border-white/15 bg-white/10 p-500 font-kia-signature text-body-1-regular text-gray-50 placeholder:font-kia-signature placeholder:text-body-1-regular placeholder:text-gray-400"
+              type="text"
+              name="phoneNum"
+              value={phoneNum}
+              onChange={onChange}
+              placeholder="전화번호"
+            />
+            <button className="h-full w-[6.5rem] rounded-lg bg-primary font-kia-signature-bold text-body-1-bold text-gray-950">
+              인증번호
+            </button>
+          </div>
+          <input
+            className="h-[3.375rem] w-full rounded-lg border border-white/15 bg-white/10 p-500 font-kia-signature text-body-1-regular text-gray-50 placeholder:font-kia-signature placeholder:text-body-1-regular placeholder:text-gray-400"
+            type="text"
+            name="verificationCode"
+            value={verificationCode}
+            onChange={onChange}
+            placeholder="인증번호"
+          />
+        </form>
+        <div className="w-full py-700">
+          <p className="font-kia-signature-bold text-title-4 text-gray-50">
+            개인정보 수집 및 이용에 동의하십니까?
+          </p>
+          <p className="text-xs text-gray-400">
+            귀하께서는 본 동의를 거부하실 권리가 있으며, 미 동의시 본 이벤트에
+            참여하실 수 없습니다.
+          </p>
+          <div className="gap-1000 pt-700 flex-center">
             동의
             <input type="radio" value="" />
-          </div>
-          <div>
             미동의
             <input type="radio" value="" />
           </div>
         </div>
-        <button type="submit">인증하기</button>
-      </form>
-      <div>info</div>
-      <div>error toast</div>
+        <Button
+          onClick={() => {
+            navigate(-1);
+          }}
+          isEnabled={isButtonEnabled}
+          defaultText="인증하기"
+          disabledText="인증하기"
+          size="small"
+        ></Button>
+        <div className="pt-700">
+          <p className="relative pl-4 font-kia-signature text-body-2-regular text-gray-400 before:absolute before:left-0 before:content-['•']">
+            본인인증은 60분간 유지되며, 이벤트 페이지 우측 상단의 새로고침
+            버튼을 통해 연장 가능합니다.
+          </p>
+          <p className="relative pl-4 font-kia-signature text-body-2-regular text-gray-400 before:absolute before:left-0 before:content-['•']">
+            페이지를 닫을 시, 인증이 만료됩니다.
+          </p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/types/AuthModal.ts
+++ b/src/types/AuthModal.ts
@@ -1,0 +1,5 @@
+export interface PhoneAuthForm {
+  name: string;
+  phoneNum: string;
+  verificationCode: string;
+}

--- a/src/types/AuthModal.ts
+++ b/src/types/AuthModal.ts
@@ -1,5 +1,20 @@
-export interface PhoneAuthForm {
+export interface PhoneAuthRequestForm {
   name: string;
   phoneNum: string;
+}
+
+export interface PhoneAuthCheckForm extends PhoneAuthRequestForm {
   verificationCode: string;
+}
+
+export interface PhoneAuthVerifyResult {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  result: TokenInfo;
+}
+
+interface TokenInfo {
+  accessToken: string;
+  expireTime: number;
 }

--- a/src/types/AuthModal.ts
+++ b/src/types/AuthModal.ts
@@ -7,6 +7,8 @@ export interface PhoneAuthCheckForm extends PhoneAuthRequestForm {
   verificationCode: string;
 }
 
+export type ErrorToastKey = "AUTH_NUM_EXPRIES" | "AUTH_NUM_INCORRECT";
+
 export interface PhoneAuthVerifyResult {
   isSuccess: boolean;
   code: number;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,22 @@
+import { ChangeEvent } from "react";
+
+export const phoneAutoHyphen = (event: ChangeEvent<HTMLInputElement>) => {
+  event.target.value = event.target.value
+    .replace(/[^0-9]/g, "")
+    .replace(/^(\d{0,3})(\d{0,4})(\d{0,4})$/g, "$1-$2-$3")
+    .replace(/(\-{1,2})$/g, "");
+};
+
+export const validatePhoneNumber = (phoneNum: string) => {
+  const phonePattern = /^\d{3}-\d{4}-\d{4}$/;
+  return phonePattern.test(phoneNum);
+};
+
+export const verifyCodeCorrector = (event: ChangeEvent<HTMLInputElement>) => {
+  event.target.value = event.target.value.replace(/[^0-9]/g, "");
+};
+
+export const validateverificationCode = (verificationCode: string) => {
+  const verificationCodePattern = /^\d{6}$/;
+  return verificationCodePattern.test(verificationCode);
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,8 @@ module.exports = {
         600: "1.25rem",
         700: "1.5rem",
         800: "2rem",
+        900: "2.25rem",
+        1000: "2.5rem",
       },
       keyframes: {
         moveText: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,5 +8,11 @@ module.exports = merge(common, {
     port: 8000,
     historyApiFallback: true,
     open: true,
+    proxy: [
+      {
+        context: ["/verification"],
+        target: "http://3.38.151.69:8080",
+      },
+    ],
   },
 });

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,7 +3,7 @@ const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
   mode: "development",
-  devtool: "eval",
+  devtool: "inline-source-map",
   devServer: {
     port: 8000,
     historyApiFallback: true,


### PR DESCRIPTION
## 🎯 이슈 번호
#50 

## 💡 작업 내용

- [x] 선착순 힌트 아래 부분에서 이동 시, 애니메이션 다시 불러오는 버그 수정
- [ ] 인증 모달 테스트 코드 작성
- [ ] 인증 관련 msw 핸들러 작성
- [ ] 인증 모달 로직 구현
- [ ] 인증 모달 스타일링 적용
- [ ] 타이머 커스텀 훅 작성

## 💡 자세한 설명

- 선착순 힌트 아래 부분에 투명한 div요소를 덧대어 아래 부분으로 이동하여도 애니메이션이 다시 반복해서 일어나지 않도록 했다.
- 인증 모달 로직을 구현했다. webpack proxy를 사용하면 실제 api 서버와도 통신할 수 있도록 했다.
- useTimer 훅을 작성하였다. useTimer에 초기 시간과 종료 되었을 때 실행될 로직이 담긴 함수를 전달하면 된다.

## 📗 참고 자료 (선택)
[자바스크립트 module.export, exports](https://overcome-the-limits.tistory.com/739)]

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

- webpack 설정 시, 환경변수를 설정하기 위해 module.exports를 함수 형태로 변경하면 .src를 찾지 못하는 오류가 발생했다.
- 인증번호가 틀렸을 때, 만료 시간이 되었을 때, 로직 
- 만료시간 타이머 hook 작성

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
